### PR TITLE
Fix 'dualityd tx dex deposit' function implementation

### DIFF
--- a/x/dex/client/cli/tx_deposit.go
+++ b/x/dex/client/cli/tx_deposit.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/NicholasDotSol/duality/x/dex/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -22,11 +23,15 @@ func CmdDeposit() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deposit [receiver] [token-a] [token-b] [list of amount-0] [list of amount-1] [list of tick-index] [list of fee] ",
 		Short: "Broadcast message deposit",
-		Args:  cobra.ExactArgs(6),
+		Args:  cobra.ExactArgs(7),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argReceiver := args[0]
 			argTokenA := args[1]
 			argTokenB := args[2]
+			argAmountsA := strings.Split(args[3], ",")
+			argAmountsB := strings.Split(args[4], ",")
+			argTicksIndexes := strings.Split(args[5], ",")
+			argFeesIndexes := strings.Split(args[6], ",")
 
 			var AmountsADec []sdk.Dec
 			var AmountsBDec []sdk.Dec
@@ -50,7 +55,7 @@ func CmdDeposit() *cobra.Command {
 					return err
 				}
 
-				AmountsADec = append(AmountsBDec, amountB)
+				AmountsBDec = append(AmountsBDec, amountB)
 			}
 
 			for _, s := range argTicksIndexes {
@@ -99,7 +104,7 @@ func CmdDeposit() *cobra.Command {
 	flags.AddTxFlagsToCmd(cmd)
 
 	cmd.Flags().StringArrayVarP(&argAmountsA, "amountA", "0", []string{}, "")
-	cmd.Flags().StringArrayVarP(&argAmountsA, "amountB", "1", []string{}, "")
+	cmd.Flags().StringArrayVarP(&argAmountsB, "amountB", "1", []string{}, "")
 	cmd.Flags().StringArrayVarP(&argTicksIndexes, "ticksIndexes", "t", []string{}, "")
 	cmd.Flags().StringArrayVarP(&argFeesIndexes, "feeIndexes", "f", []string{}, "")
 


### PR DESCRIPTION
Calling deposit through the CLI should work like:
```sh
address=$(dualityd keys show $person --output json | jq -r .address)
dualityd tx dex deposit "$address" tokenA tokenB 1 1 0 0 --from "$person"
```
