### PR TITLE
Revert "ADD CLI disclaimer (#167)"

### DIFF
--- a/x/dex/client/cli/tx.go
+++ b/x/dex/client/cli/tx.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	// "github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/NicholasDotSol/duality/x/dex/types"
-	"runtime"
 )
 
 var (
@@ -31,9 +30,6 @@ func GetTxCmd() *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	// TEMP: Temporary warning until CLI commands have been fully tested
-	PrintCLIWarning()
-
 	cmd.AddCommand(CmdDeposit())
 	cmd.AddCommand(CmdWithdrawl())
 	cmd.AddCommand(CmdSwap())
@@ -43,13 +39,4 @@ func GetTxCmd() *cobra.Command {
 	// this line is used by starport scaffolding # 1
 
 	return cmd
-}
-
-func PrintCLIWarning(){
-	colorChar := "\033[31m"
-	colorEnd := "\033[0m"
-	if runtime.GOOS == "windows" {
-		colorChar, colorEnd = "", ""
-	}
-	fmt.Printf(colorChar + "\n!! WARNING CLI COMMANDS ARE STILL IN EARLY BETA !! \nNOT ALL FUNCTIONALITY HAS BEEN TESTED\n" + colorEnd)
 }


### PR DESCRIPTION
Reverting because this will break CLI scripting unless we move output to STDERR. Alternatively we could put a disclaimer about the known issues with the CLI on STDERR.

This reverts commit 2d1e9b9089ed3fdb60a289a6745b28398e04d924.