### PR TITLE
Introduce Pool object

### DIFF
--- a/x/dex/keeper/core.go
+++ b/x/dex/keeper/core.go
@@ -11,9 +11,12 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-// NOTE: Currently we are using TruncateInt in multiple places for converting Decs back into sdk.Ints. This may create some accounting anomalies but seems preferable to other alternatives. See full ADR here: https://www.notion.so/dualityxyz/A-Modest-Proposal-For-Truncating-696a919d59254876a617f82fb9567895
+// NOTE: Currently we are using TruncateInt in multiple places for converting Decs back into sdk.Ints.
+// This may create some accounting anomalies but seems preferable to other alternatives.
+// See full ADR here: https://www.notion.so/dualityxyz/A-Modest-Proposal-For-Truncating-696a919d59254876a617f82fb9567895
 
-// Handles core logic for MsgDeposit, checking and initializing data structures (tick, pair), calculating shares based on amount deposited, and sending funds to moduleAddress
+// Handles core logic for MsgDeposit, checking and initializing data structures (tick, pair), calculating
+// shares based on amount deposited, and sending funds to moduleAddress
 func (k Keeper) DepositCore(
 	goCtx context.Context,
 	msg *types.MsgDeposit,
@@ -45,7 +48,6 @@ func (k Keeper) DepositCore(
 	for i, amount0 := range amounts0 {
 		amount1 := amounts1[i]
 		tickIndex := msg.TickIndexes[i]
-		price1To0 := CalcPrice1To0(tickIndex)
 		feeIndex := msg.FeeIndexes[i]
 		fee := FeeTier[feeIndex].Fee
 		curTick0to1 := pair.CurrentTick0To1
@@ -65,21 +67,20 @@ func (k Keeper) DepositCore(
 
 		lowerTick := k.GetOrInitTick(goCtx, pairId, lowerTickIndex)
 		upperTick := k.GetOrInitTick(goCtx, pairId, upperTickIndex)
-
-		lowerReserve0 := &lowerTick.TickData.Reserve0AndShares[feeIndex].Reserve0
-		lowerTotalShares := &lowerTick.TickData.Reserve0AndShares[feeIndex].TotalShares
-		upperReserve1 := &upperTick.TickData.Reserve1[feeIndex]
-
-		trueAmount0, trueAmount1, sharesMinted := CalcTrueAmounts(
-			price1To0,
-			*lowerReserve0,
-			*upperReserve1,
-			amount0,
-			amount1,
-			*lowerTotalShares,
+		pool := NewPool(
+			pairId,
+			tickIndex,
+			feeIndex,
+			&lowerTick,
+			&upperTick,
 		)
+		oldReserve0 := pool.GetLowerReserve0()
+		oldReserve1 := pool.GetUpperReserve1()
 
-		if trueAmount0.Equal(sdk.ZeroInt()) && trueAmount1.Equal(sdk.ZeroInt()) {
+		inAmount0, inAmount1, outShares := pool.Deposit(amount0, amount1)
+		pool.Save(goCtx, k)
+
+		if inAmount0.Equal(sdk.ZeroInt()) && inAmount1.Equal(sdk.ZeroInt()) {
 			ctx.EventManager().EmitEvent(types.CreateDepositFailedEvent(
 				msg.Creator,
 				msg.Receiver,
@@ -87,26 +88,23 @@ func (k Keeper) DepositCore(
 				token1,
 				fmt.Sprint(tickIndex),
 				fmt.Sprint(tickIndex),
-				lowerReserve0.String(),
-				upperReserve1.String(),
+				oldReserve0.String(),
+				oldReserve1.String(),
 				amount0.String(),
 				amount1.String(),
 			))
 			continue
 		}
 
-		*lowerReserve0 = lowerReserve0.Add(trueAmount0)
-		*lowerTotalShares = lowerTotalShares.Add(sharesMinted)
-		*upperReserve1 = upperReserve1.Add(trueAmount1)
 		k.SetTradingPair(ctx, pair)
-		k.SetTick(ctx, pairId, lowerTick)
-		k.SetTick(ctx, pairId, upperTick)
 
 		k.UpdateTickPointersPostAddToken0(goCtx, &pair, &lowerTick)
 		k.UpdateTickPointersPostAddToken1(goCtx, &pair, &upperTick)
 
-		amounts0Deposited[i] = trueAmount0
-		amounts1Deposited[i] = trueAmount1
+		amounts0Deposited[i] = inAmount0
+		amounts1Deposited[i] = inAmount1
+		totalAmountReserve0 = totalAmountReserve0.Add(inAmount0)
+		totalAmountReserve1 = totalAmountReserve1.Add(inAmount1)
 
 		passedDeposit++
 
@@ -117,16 +115,13 @@ func (k Keeper) DepositCore(
 				PairId:      pairId,
 				TickIndex:   tickIndex,
 				FeeIndex:    feeIndex,
-				SharesOwned: sharesMinted,
+				SharesOwned: outShares,
 			}
 		} else {
-			shares.SharesOwned = shares.SharesOwned.Add(sharesMinted)
+			shares.SharesOwned = shares.SharesOwned.Add(outShares)
 		}
 
 		k.SetShares(ctx, shares)
-
-		totalAmountReserve0 = totalAmountReserve0.Add(trueAmount0)
-		totalAmountReserve1 = totalAmountReserve1.Add(trueAmount1)
 
 		ctx.EventManager().EmitEvent(types.CreateDepositEvent(
 			msg.Creator,
@@ -135,13 +130,12 @@ func (k Keeper) DepositCore(
 			token1,
 			fmt.Sprint(msg.TickIndexes[i]),
 			fmt.Sprint(msg.FeeIndexes[i]),
-			lowerReserve0.Sub(trueAmount0).String(),
-			upperReserve1.Sub(trueAmount1).String(),
-			lowerReserve0.String(),
-			upperReserve1.String(),
-			sharesMinted.String(),
-		),
-		)
+			pool.GetLowerReserve0().Sub(inAmount0).String(),
+			pool.GetUpperReserve1().Sub(inAmount1).String(),
+			pool.GetLowerReserve0().String(),
+			pool.GetUpperReserve1().String(),
+			outShares.String(),
+		))
 	}
 
 	if passedDeposit == 0 {
@@ -194,6 +188,9 @@ func (k Keeper) WithdrawCore(goCtx context.Context, msg *types.MsgWithdrawl, tok
 			return types.ErrValidShareNotFound
 		}
 		userSharesOwned := &shareOwner.SharesOwned
+		if userSharesOwned.LT(sharesToRemove) {
+			return types.ErrNotEnoughShares
+		}
 
 		feeValue, found := k.GetFeeTier(ctx, feeIndex)
 		if !found {
@@ -208,36 +205,30 @@ func (k Keeper) WithdrawCore(goCtx context.Context, msg *types.MsgWithdrawl, tok
 			return types.ErrValidTickNotFound
 		}
 
-		lowerTickFeeTotalShares := &lowerTick.TickData.Reserve0AndShares[feeIndex].TotalShares
-		lowerTickFeeReserve0 := &lowerTick.TickData.Reserve0AndShares[feeIndex].Reserve0
-		upperTickFeeReserve1 := &upperTick.TickData.Reserve1[feeIndex]
-		if lowerTickFeeTotalShares.Equal(sdk.ZeroInt()) {
-			return types.ErrNotEnoughShares
+		pool := NewPool(
+			pairId,
+			tickIndex,
+			feeIndex,
+			&lowerTick,
+			&upperTick,
+		)
+		outAmount0, outAmount1, err := pool.Withdraw(sharesToRemove)
+		if err != nil {
+			return err
 		}
+		pool.Save(goCtx, k)
 
-		sharesToRemoveDec := sdk.MinInt(sharesToRemove, *userSharesOwned).ToDec()
-		ownershipRatio := sharesToRemoveDec.Quo(lowerTickFeeTotalShares.ToDec())
-		// See top NOTE on rounding
-		reserve1ToRemove := ownershipRatio.MulInt(*upperTickFeeReserve1).TruncateInt()
-		reserve0ToRemove := ownershipRatio.MulInt(*lowerTickFeeReserve0).TruncateInt()
-
-		*lowerTickFeeReserve0 = lowerTickFeeReserve0.Sub(reserve0ToRemove)
-		*upperTickFeeReserve1 = upperTickFeeReserve1.Sub(reserve1ToRemove)
-		*lowerTickFeeTotalShares = lowerTickFeeTotalShares.Sub(sharesToRemove)
 		*userSharesOwned = userSharesOwned.Sub(sharesToRemove)
-
-		totalReserve0ToRemove = totalReserve0ToRemove.Add(reserve0ToRemove)
-		totalReserve1ToRemove = totalReserve1ToRemove.Add(reserve1ToRemove)
-
 		k.SetShares(ctx, shareOwner)
-		k.SetTick(ctx, pairId, upperTick)
-		k.SetTick(ctx, pairId, lowerTick)
 
-		if totalReserve0ToRemove.GT(sdk.ZeroInt()) {
+		totalReserve0ToRemove = totalReserve0ToRemove.Add(outAmount0)
+		totalReserve1ToRemove = totalReserve1ToRemove.Add(outAmount1)
+
+		if outAmount0.GT(sdk.ZeroInt()) {
 			k.UpdateTickPointersPostRemoveToken0(goCtx, &pair, &lowerTick)
 		}
 
-		if totalReserve1ToRemove.GT(sdk.ZeroInt()) {
+		if outAmount1.GT(sdk.ZeroInt()) {
 			k.UpdateTickPointersPostRemoveToken1(goCtx, &pair, &upperTick)
 		}
 
@@ -248,10 +239,10 @@ func (k Keeper) WithdrawCore(goCtx context.Context, msg *types.MsgWithdrawl, tok
 			token1,
 			fmt.Sprint(msg.TickIndexes[i]),
 			fmt.Sprint(msg.FeeIndexes[i]),
-			lowerTickFeeReserve0.Add(reserve0ToRemove).String(),
-			upperTickFeeReserve1.Add(reserve1ToRemove).String(),
-			lowerTickFeeReserve0.String(),
-			upperTickFeeReserve1.String(),
+			pool.LowerTick0.TickData.Reserve0AndShares[feeIndex].Reserve0.Add(outAmount0).String(),
+			pool.UpperTick1.TickData.Reserve1[feeIndex].Add(outAmount1).String(),
+			pool.LowerTick0.TickData.Reserve0AndShares[feeIndex].Reserve0.String(),
+			pool.UpperTick1.TickData.Reserve1[feeIndex].String(),
 			sharesToRemove.String(),
 		))
 	}
@@ -300,12 +291,12 @@ func (k Keeper) Swap0to1(goCtx context.Context, msg *types.MsgSwap, token0 strin
 		return sdk.ZeroInt(), sdk.ZeroInt(), types.ErrNotEnoughLiquidity
 	}
 
-	amount_left := msg.AmountIn.ToDec()
-	amount_out := sdk.ZeroInt()
+	remainingInAmount0 := msg.AmountIn
+	totalOutAmount1 := sdk.ZeroInt()
 
 	// verify that amount left is not zero and that there are additional valid ticks to check
 	// for !amount_left.Equal(sdk.ZeroInt()) && pair.TokenPair.CurrentTick0To1 <= pair.MaxTick {
-	for !amount_left.Equal(sdk.ZeroDec()) && pair.CurrentTick0To1 <= pair.MaxTick {
+	for remainingInAmount0.GT(sdk.ZeroInt()) && pair.CurrentTick0To1 <= pair.MaxTick {
 		Current1Data, Current1Found := k.GetTick(ctx, pairId, pair.CurrentTick0To1)
 		if !Current1Found {
 			pair.CurrentTick0To1++
@@ -314,7 +305,7 @@ func (k Keeper) Swap0to1(goCtx context.Context, msg *types.MsgSwap, token0 strin
 
 		var i uint64 = 0
 
-		for i < feeSize && !amount_left.Equal(sdk.ZeroDec()) {
+		for i < feeSize && remainingInAmount0.GT(sdk.ZeroInt()) {
 			fee := FeeTier[i].Fee
 			Current0Data, found := k.GetTick(ctx, pairId, pair.CurrentTick0To1-2*fee)
 			if !found {
@@ -322,44 +313,34 @@ func (k Keeper) Swap0to1(goCtx context.Context, msg *types.MsgSwap, token0 strin
 				continue
 			}
 
-			price_0to1 := CalcPrice0To1(pair.CurrentTick0To1)
-			currentReserve0 := Current0Data.TickData.Reserve0AndShares[i].Reserve0
-			currentReserve1 := Current1Data.TickData.Reserve1[i]
-			// See top NOTE on rounding
-			amountOutTemp := price_0to1.Mul(amount_left).TruncateInt()
-			amountInTemp := currentReserve1.ToDec().Quo(price_0to1).TruncateInt()
-
-			if amountOutTemp.Add(amount_out).LT(msg.MinOut) {
-				return sdk.ZeroInt(), sdk.ZeroInt(), types.ErrNotEnoughLiquidity
-			}
-
-			if currentReserve1.LT(amountOutTemp) {
-				Current0Data.TickData.Reserve0AndShares[i].Reserve0 = currentReserve0.Add(amountInTemp)
-				Current1Data.TickData.Reserve1[i] = sdk.ZeroInt()
-				amount_out = amount_out.Add(currentReserve1)
-				amount_left = amount_left.Sub(amountInTemp.ToDec())
-
-			} else {
-
-				Current0Data.TickData.Reserve0AndShares[i].Reserve0 = currentReserve0.Add(amount_left.TruncateInt())
-				Current1Data.TickData.Reserve1[i] = currentReserve1.Sub(amountOutTemp)
-				amount_out = amount_out.Add(amountOutTemp)
-				amount_left = sdk.ZeroDec()
-			}
-
-			i++
-
-			//Make updates to Tick containing reserve0/1 data to the KVStore
-			k.SetTick(ctx, pairId, Current0Data)
-			// TODO: Return to this, maybe is receiving the wrong tick
+			pool := NewPool(
+				pairId,
+				pair.CurrentTick0To1-fee,
+				i,
+				&Current0Data,
+				&Current1Data,
+			)
+			inAmount0, outAmount1 := pool.Swap0To1(remainingInAmount0)
+			remainingInAmount0 = remainingInAmount0.Sub(inAmount0)
+			totalOutAmount1 = totalOutAmount1.Add(outAmount1)
+			pool.Save(goCtx, k)
 			k.UpdateTickPointersPostAddToken0(goCtx, &pair, &Current0Data)
+			i++
 		}
 
-		k.SetTick(ctx, pairId, Current1Data)
-		if i == feeSize && amount_left.GT(sdk.ZeroDec()) {
+		if i == feeSize && remainingInAmount0.GT(sdk.ZeroInt()) {
 			var err error
-			amount_left, amount_out, err = k.SwapLimitOrder0to1(goCtx, pairId, token1, amount_out, amount_left, pair.CurrentTick0To1)
-			// err = fmt.Errorf("dummy error for testing")
+			var remainingInAmount0Dec sdk.Dec
+			remainingInAmount0Dec, totalOutAmount1, err = k.SwapLimitOrder0to1(
+				goCtx,
+				pairId,
+				token1,
+				totalOutAmount1,
+				remainingInAmount0.ToDec(),
+				pair.CurrentTick0To1,
+			)
+			remainingInAmount0 = remainingInAmount0Dec.TruncateInt()
+
 			if err != nil {
 				return sdk.ZeroInt(), sdk.ZeroInt(), err
 			}
@@ -370,17 +351,17 @@ func (k Keeper) Swap0to1(goCtx context.Context, msg *types.MsgSwap, token0 strin
 	k.SetTradingPair(ctx, pair)
 
 	// Check to see if amount_out meets the threshold of minOut
-	if amount_out.LT(msg.MinOut) {
+	if totalOutAmount1.LT(msg.MinOut) {
 		return sdk.ZeroInt(), sdk.ZeroInt(), types.ErrNotEnoughLiquidity
 	}
 
 	ctx.EventManager().EmitEvent(types.CreateSwapEvent(msg.Creator, msg.Receiver,
-		token0, token1, msg.TokenIn, msg.AmountIn.String(), amount_out.String(), msg.MinOut.String(),
+		token0, token1, msg.TokenIn, msg.AmountIn.String(), totalOutAmount1.String(), msg.MinOut.String(),
 	))
 
 	// Returns amount_out to keeper/msg.server: Swap
 	// @Dev token transfers happen in keeper/msg.server: Swap
-	return amount_out, amount_left.TruncateInt(), nil
+	return totalOutAmount1, remainingInAmount0, nil
 }
 
 // Handles core logic for the asset 1 to asset 0 direction of MsgSwap; faciliates swapping amount1 for some amount of amount0, given a specified pair (token0, token1)
@@ -397,9 +378,9 @@ func (k Keeper) Swap1to0(goCtx context.Context, msg *types.MsgSwap, token0 strin
 		return sdk.ZeroInt(), sdk.ZeroInt(), types.ErrNotEnoughLiquidity
 	}
 
-	amount_left := msg.AmountIn.ToDec()
-	amount_out := sdk.ZeroInt()
-	for !amount_left.Equal(sdk.ZeroDec()) && pair.CurrentTick1To0 >= pair.MinTick {
+	remainingInAmount1 := msg.AmountIn
+	totalOutAmount0 := sdk.ZeroInt()
+	for remainingInAmount1.GT(sdk.ZeroInt()) && pair.CurrentTick1To0 >= pair.MinTick {
 
 		Current0Data, Current0Found := k.GetTick(ctx, pairId, pair.CurrentTick1To0)
 		if !Current0Found {
@@ -408,50 +389,44 @@ func (k Keeper) Swap1to0(goCtx context.Context, msg *types.MsgSwap, token0 strin
 		}
 
 		var i uint64 = 0
-		for i < feeSize && !amount_left.Equal(sdk.ZeroDec()) {
-			fee := FeeTier[i].Fee
 
+		for i < feeSize && remainingInAmount1.GT(sdk.ZeroInt()) {
+			fee := FeeTier[i].Fee
 			Current1Data, found := k.GetTick(ctx, pairId, pair.CurrentTick1To0+2*fee)
 			if !found {
 				i++
 				continue
 			}
 
-			price_1to0 := CalcPrice1To0(pair.CurrentTick1To0)
-			currentReserve0 := Current0Data.TickData.Reserve0AndShares[i].Reserve0
-			currentReserve1 := Current1Data.TickData.Reserve1[i]
-			// See top NOTE on rounding
-			amountOutTemp := price_1to0.Mul(amount_left).TruncateInt()
-			amountInTemp := currentReserve0.ToDec().Quo(price_1to0).TruncateInt()
-
-			if amountOutTemp.Add(amount_out).LT(msg.MinOut) {
-				return sdk.ZeroInt(), sdk.ZeroInt(), types.ErrNotEnoughLiquidity
-			}
-
-			// If there is not enough to complete the trade
-			if currentReserve0.LT(amountOutTemp) {
-				Current0Data.TickData.Reserve0AndShares[i].Reserve0 = sdk.ZeroInt()
-				Current1Data.TickData.Reserve1[i] = currentReserve1.Add(amountInTemp)
-				amount_out = amount_out.Add(currentReserve0)
-				amount_left = amount_left.Sub(amountInTemp.ToDec())
-			} else {
-				Current0Data.TickData.Reserve0AndShares[i].Reserve0 = currentReserve0.Sub(amountOutTemp)
-				Current1Data.TickData.Reserve1[i] = currentReserve1.Add(amount_left.TruncateInt())
-				amount_out = amount_out.Add(amountOutTemp)
-				amount_left = sdk.ZeroDec()
-			}
-
-			i++
-
-			k.SetTick(ctx, pairId, Current1Data)
+			pool := NewPool(
+				pairId,
+				pair.CurrentTick1To0+fee,
+				i,
+				&Current0Data,
+				&Current1Data,
+			)
+			inAmount1, outAmount0 := pool.Swap1To0(remainingInAmount1)
+			remainingInAmount1 = remainingInAmount1.Sub(inAmount1)
+			totalOutAmount0 = totalOutAmount0.Add(outAmount0)
+			pool.Save(goCtx, k)
 			k.UpdateTickPointersPostAddToken1(goCtx, &pair, &Current1Data)
+			i++
 		}
 
 		k.SetTick(ctx, pairId, Current0Data)
 
-		if i == feeSize && amount_left.GT(sdk.ZeroDec()) {
+		if i == feeSize && remainingInAmount1.GT(sdk.ZeroInt()) {
 			var err error
-			amount_left, amount_out, err = k.SwapLimitOrder1to0(goCtx, pairId, token0, amount_out, amount_left, pair.CurrentTick1To0)
+			var remainingInAmount1Dec sdk.Dec
+			remainingInAmount1Dec, totalOutAmount0, err = k.SwapLimitOrder1to0(
+				goCtx,
+				pairId,
+				token0,
+				totalOutAmount0,
+				remainingInAmount1.ToDec(),
+				pair.CurrentTick1To0,
+			)
+			remainingInAmount1 = remainingInAmount1Dec.TruncateInt()
 
 			if err != nil {
 				return sdk.ZeroInt(), sdk.ZeroInt(), err
@@ -462,15 +437,15 @@ func (k Keeper) Swap1to0(goCtx context.Context, msg *types.MsgSwap, token0 strin
 
 	k.SetTradingPair(ctx, pair)
 
-	if amount_out.LT(msg.MinOut) {
+	if totalOutAmount0.LT(msg.MinOut) {
 		return sdk.ZeroInt(), sdk.ZeroInt(), types.ErrNotEnoughLiquidity
 	}
 
 	ctx.EventManager().EmitEvent(types.CreateSwapEvent(msg.Creator, msg.Receiver,
-		token0, token1, msg.TokenIn, msg.AmountIn.String(), amount_out.String(), msg.MinOut.String(),
+		token0, token1, msg.TokenIn, msg.AmountIn.String(), totalOutAmount0.String(), msg.MinOut.String(),
 	))
 
-	return amount_out, amount_left.TruncateInt(), nil
+	return totalOutAmount0, remainingInAmount1, nil
 }
 
 // Handles swapping asset 0 for asset 1 through any active limit orders at a specified tick
@@ -847,7 +822,7 @@ func (k Keeper) WithdrawFilledLimitOrderCore(
 	ratioFilled := amountFilled.QuoInt(tranche.TotalTokenIn)
 	maxAllowedToWithdraw := sdk.MinInt(
 		ratioFilled.MulInt(trancheUser.SharesOwned).TruncateInt(), // cannot withdraw more than what's been filled
-		trancheUser.SharesOwned.Sub(trancheUser.SharesCancelled), // cannot withdraw more than what you own
+		trancheUser.SharesOwned.Sub(trancheUser.SharesCancelled),  // cannot withdraw more than what you own
 	)
 	amountOutTokenIn := maxAllowedToWithdraw.Sub(trancheUser.SharesWithdrawn)
 

--- a/x/dex/keeper/core_helper.go
+++ b/x/dex/keeper/core_helper.go
@@ -84,12 +84,6 @@ func (k Keeper) GetOrInitTick(goCtx context.Context, pairId string, tickIndex in
 	return tick
 }
 
-func CalcShares(amount0 sdk.Int, amount1 sdk.Int, priceCenter1To0 sdk.Dec) sdk.Dec {
-	amount0Dec := amount0.ToDec()
-	amount1Dec := amount1.ToDec()
-	return amount0Dec.Add(amount1Dec.Mul(priceCenter1To0))
-}
-
 func (k Keeper) GetOrInitLimitOrderTrancheUser(
 	goCtx context.Context,
 	pairId string,

--- a/x/dex/keeper/pool.go
+++ b/x/dex/keeper/pool.go
@@ -1,0 +1,192 @@
+package keeper
+
+import (
+	"context"
+
+	"github.com/NicholasDotSol/duality/x/dex/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type Pool struct {
+	PairId     string
+	TickIndex  int64
+	FeeIndex   uint64
+	LowerTick0 *types.Tick
+	UpperTick1 *types.Tick
+}
+
+func NewPool(
+	pairId string,
+	tickIndex int64,
+	feeIndex uint64,
+	lowerTick0 *types.Tick,
+	upperTick1 *types.Tick,
+) Pool {
+	return Pool{
+		PairId:     pairId,
+		TickIndex:  tickIndex,
+		FeeIndex:   feeIndex,
+		LowerTick0: lowerTick0,
+		UpperTick1: upperTick1,
+	}
+}
+
+func (p *Pool) GetLowerReserve0() sdk.Int {
+	return p.LowerTick0.TickData.Reserve0AndShares[p.FeeIndex].Reserve0
+}
+
+func (p *Pool) GetUpperReserve1() sdk.Int {
+	return p.UpperTick1.TickData.Reserve1[p.FeeIndex]
+}
+
+func (p *Pool) GetTotalShares() sdk.Int {
+	return p.LowerTick0.TickData.Reserve0AndShares[p.FeeIndex].TotalShares
+}
+
+func (p *Pool) Swap0To1(maxAmount0 sdk.Int) (inAmount0 sdk.Int, outAmount1 sdk.Int) {
+	price0To1 := CalcPrice0To1(p.UpperTick1.TickIndex)
+	price1To0 := sdk.OneDec().Quo(price0To1)
+	reserves1 := &p.UpperTick1.TickData.Reserve1[p.FeeIndex]
+	reserves0 := &p.LowerTick0.TickData.Reserve0AndShares[p.FeeIndex].Reserve0
+	maxAmount1 := maxAmount0.ToDec().Mul(price0To1).TruncateInt()
+	if reserves1.LT(maxAmount1) {
+		outAmount1 = *reserves1
+		inAmount0 = reserves1.ToDec().Mul(price1To0).TruncateInt()
+		*reserves0 = reserves0.Add(inAmount0)
+		*reserves1 = sdk.ZeroInt()
+	} else {
+		outAmount1 = maxAmount0.ToDec().Mul(price0To1).TruncateInt()
+		*reserves0 = reserves0.Add(maxAmount0)
+		*reserves1 = reserves1.Sub(outAmount1)
+		inAmount0 = maxAmount0
+	}
+	return inAmount0, outAmount1
+}
+
+func (p *Pool) Swap1To0(maxAmount1 sdk.Int) (inAmount1 sdk.Int, outAmount0 sdk.Int) {
+	price1To0 := CalcPrice1To0(p.LowerTick0.TickIndex)
+	price0To1 := sdk.OneDec().Quo(price1To0)
+	reserves1 := &p.UpperTick1.TickData.Reserve1[p.FeeIndex]
+	reserves0 := &p.LowerTick0.TickData.Reserve0AndShares[p.FeeIndex].Reserve0
+	maxAmount0 := maxAmount1.ToDec().Mul(price1To0).TruncateInt()
+	if reserves0.LT(maxAmount0) {
+		outAmount0 = *reserves0
+		inAmount1 = reserves0.ToDec().Mul(price0To1).TruncateInt()
+		*reserves1 = reserves1.Add(inAmount1)
+		*reserves0 = sdk.ZeroInt()
+	} else {
+		outAmount0 = maxAmount1.ToDec().Mul(price1To0).TruncateInt()
+		*reserves1 = reserves1.Add(maxAmount1)
+		*reserves0 = reserves0.Sub(outAmount0)
+		inAmount1 = maxAmount1
+	}
+	return inAmount1, outAmount0
+}
+
+// Balance trueAmount1 to the pool ratio
+func CalcGreatestMatchingRatio(
+	targetAmount0 sdk.Int,
+	targetAmount1 sdk.Int,
+	amount0 sdk.Int,
+	amount1 sdk.Int,
+) (resultAmount0 sdk.Int, resultAmount1 sdk.Int) {
+	targetAmount0Dec := targetAmount0.ToDec()
+	targetAmount1Dec := targetAmount1.ToDec()
+
+	// See spec: https://www.notion.so/dualityxyz/Autoswap-Spec-e856fa7b2438403c95147010d479b98c
+	if targetAmount1.GT(sdk.ZeroInt()) {
+		resultAmount0 = sdk.MinInt(
+			amount0,
+			amount1.ToDec().Mul(targetAmount0Dec).Quo(targetAmount1Dec).TruncateInt())
+	} else {
+		resultAmount0 = amount0
+	}
+
+	if targetAmount0.GT(sdk.ZeroInt()) {
+		resultAmount1 = sdk.MinInt(
+			amount1,
+			amount0.ToDec().Mul(targetAmount1Dec).Quo(targetAmount0Dec).TruncateInt())
+	} else {
+		resultAmount1 = amount1
+	}
+
+	return resultAmount0, resultAmount1
+}
+
+// Mutates the Pool object and returns relevant change variables. Deposit is not commited until
+// pool.save() is called or the underlying ticks are saved; this method does not use any keeper methods.
+func (p *Pool) Deposit(maxAmount0 sdk.Int, maxAmount1 sdk.Int) (inAmount0 sdk.Int, inAmount1 sdk.Int, outShares sdk.Int) {
+	lowerReserve0 := &p.LowerTick0.TickData.Reserve0AndShares[p.FeeIndex].Reserve0
+	lowerTotalShares := &p.LowerTick0.TickData.Reserve0AndShares[p.FeeIndex].TotalShares
+	upperReserve1 := &p.UpperTick1.TickData.Reserve1[p.FeeIndex]
+
+	inAmount0, inAmount1 = CalcGreatestMatchingRatio(
+		*lowerReserve0,
+		*upperReserve1,
+		maxAmount0,
+		maxAmount1,
+	)
+
+	if inAmount0.Equal(sdk.ZeroInt()) && inAmount1.Equal(sdk.ZeroInt()) {
+		return sdk.ZeroInt(), sdk.ZeroInt(), sdk.ZeroInt()
+	}
+
+	outShares = p.CalcSharesMinted(
+		*lowerReserve0,
+		*upperReserve1,
+		*lowerTotalShares,
+		inAmount0,
+		inAmount1,
+	)
+
+	*lowerReserve0 = lowerReserve0.Add(inAmount0)
+	*upperReserve1 = upperReserve1.Add(inAmount1)
+	*lowerTotalShares = lowerTotalShares.Add(outShares)
+	return inAmount0, inAmount1, outShares
+}
+
+func (p *Pool) CalcSharesMinted(
+	reserve0 sdk.Int,
+	reserve1 sdk.Int,
+	totalShares sdk.Int,
+	amount0 sdk.Int,
+	amount1 sdk.Int,
+) (sharesMinted sdk.Int) {
+	price1To0 := CalcPrice1To0(p.TickIndex) // center tick
+	valueMintedToken0 := CalcShares(amount0, amount1, price1To0)
+	valueExistingToken0 := CalcShares(reserve0, reserve1, price1To0)
+	if valueExistingToken0.GT(sdk.ZeroDec()) {
+		sharesMinted = valueMintedToken0.Quo(valueExistingToken0).Mul(totalShares.ToDec()).TruncateInt()
+	} else {
+		sharesMinted = valueMintedToken0.TruncateInt()
+	}
+	return sharesMinted
+}
+
+func (p *Pool) Withdraw(sharesToRemove sdk.Int) (outAmount0 sdk.Int, outAmount1 sdk.Int, err error) {
+	totalShares := &p.LowerTick0.TickData.Reserve0AndShares[p.FeeIndex].TotalShares
+	reserves0 := &p.LowerTick0.TickData.Reserve0AndShares[p.FeeIndex].Reserve0
+	reserves1 := &p.UpperTick1.TickData.Reserve1[p.FeeIndex]
+	if totalShares.LT(sharesToRemove) {
+		return sdk.ZeroInt(), sdk.ZeroInt(), types.ErrNotEnoughShares
+	}
+	ownershipRatio := sharesToRemove.ToDec().Quo(totalShares.ToDec())
+	outAmount1 = ownershipRatio.Mul(reserves1.ToDec()).TruncateInt()
+	outAmount0 = ownershipRatio.Mul(reserves0.ToDec()).TruncateInt()
+	*reserves0 = reserves0.Sub(outAmount0)
+	*reserves1 = reserves1.Sub(outAmount1)
+	*totalShares = totalShares.Sub(sharesToRemove)
+	return outAmount0, outAmount1, nil
+}
+
+func CalcShares(amount0 sdk.Int, amount1 sdk.Int, priceCenter1To0 sdk.Dec) sdk.Dec {
+	amount0Dec := amount0.ToDec()
+	amount1Dec := amount1.ToDec()
+	return amount0Dec.Add(amount1Dec.Mul(priceCenter1To0))
+}
+
+func (p *Pool) Save(ctx context.Context, keeper Keeper) {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	keeper.SetTick(sdkCtx, p.PairId, *p.LowerTick0)
+	keeper.SetTick(sdkCtx, p.PairId, *p.UpperTick1)
+}

--- a/x/dex/keeper/swap_onlylimitorder_unit_test.go
+++ b/x/dex/keeper/swap_onlylimitorder_unit_test.go
@@ -161,7 +161,7 @@ func (s *MsgServerTestSuite) TestSwapOnlyLO1to0MovesCurr1To0() {
 
 	// WHEN
 	// swap 15 of token B for A with minOut 14
-	s.bobMarketSells("TokenB", 15, 14)
+	s.bobMarketSells("TokenB", 15, 13)
 
 	// THEN
 	// current 1to0 moves to -3
@@ -397,23 +397,6 @@ func (s *MsgServerTestSuite) TestSwapOnlyLOExhaustLOCorrectExecution() {
 	s.assertBobBalancesEpsilon(bobBalanceSetupB.Sub(expectedAmountIn), amountOutSetup.Add(expectedAmountOut))
 	s.assertDexBalancesEpsilon(expectedAmountIn.Add(amountInSetup), limitLiquiditySetup.Sub(expectedAmountOut))
 	s.assertLimitLiquidityAtTickInt("TokenB", 1, sdk.NewInt(20).Sub(amountOutSetup).Sub(expectedAmountOut))
-}
-
-func (s *MsgServerTestSuite) TestBadSwap() {
-	s.fundAliceBalances(50, 50)
-	s.fundBobBalances(50, 0)
-	// GIVEN
-	// place LO selling 10 of token B at tick 1
-	i := 0
-	for i < 50{
-		s.aliceLimitSells("TokenB", i, 1)
-		i++
-	}
-	amountLeft, amountOut := s.calculateSingleSwapOnlyLOAToB(49, 50, 50)
-
-	s.bobMarketSells("TokenA", 50, 0)
-	s.assertBobBalancesInt(sdk.NewInt(0), amountOut) // Fails with: expected 49 != actual 25
-	s.Assert().Equal(amountLeft, sdk.NewInt(0))
 }
 
 func (s *MsgServerTestSuite) TestSwapOnlyLOPartiallyFilled0to1DoesntMove0to1() {


### PR DESCRIPTION
All tests still passing. We will need to move our test coverage to this pool object, but since we have good top-level coverage I'd rather merge now and get out of the way of several other development efforts, like autoswap and tokenizer.