### PR TITLE
fix: on Rename FeeList to FeeTier

### DIFF
--- a/networks/duality-testnet-1/pregenesis/dex.json
+++ b/networks/duality-testnet-1/pregenesis/dex.json
@@ -116,7 +116,7 @@
         }
       ],
       "tokensCount": 28,
-      "feeListList": [
+      "FeeTierList": [
         {
           "id": 0,
           "fee": 1
@@ -134,7 +134,7 @@
           "fee": 100
         }
       ],
-      "feeListCount": 4
+      "FeeTierCount": 4
     }
   }
 }


### PR DESCRIPTION
Add genesis fee tiers for base fee tier state in dockerized chains.

Following the changes in https://github.com/duality-labs/duality/pull/197 I needed to edit the genesis state to be able to start a chain containing fee tiers (else deposits will fail)