### PR TITLE
App type fix

### DIFF
--- a/tests/e2e/app_initers.go
+++ b/tests/e2e/app_initers.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"encoding/json"
+
 	"github.com/cosmos/cosmos-sdk/simapp"
 
 	ibctesting "github.com/cosmos/interchain-security/legacy_ibc_testing/testing"
@@ -11,21 +12,12 @@ import (
 	tmdb "github.com/tendermint/tm-db"
 
 	appConsumer "github.com/NicholasDotSol/duality/app"
-	appProvider "github.com/cosmos/interchain-security/app/provider"
 )
 
-// ConsumerAppIniter implements ibctesting.AppIniter for a consumer app
-func ConsumerAppIniter() (ibctesting.TestingApp, map[string]json.RawMessage) {
+// DualityAppIniter implements ibctesting.AppIniter for the duality consumer app
+func DualityAppIniter() (ibctesting.TestingApp, map[string]json.RawMessage) {
 	encoding := cosmoscmd.MakeEncodingConfig(appConsumer.ModuleBasics)
 	testApp := appConsumer.New(log.NewNopLogger(), tmdb.NewMemDB(), nil, true, map[int64]bool{},
 		simapp.DefaultNodeHome, 5, encoding, simapp.EmptyAppOptions{}).(ibctesting.TestingApp)
 	return testApp, appConsumer.NewDefaultGenesisState(encoding.Marshaler)
-}
-
-// ProviderAppIniter implements ibctesting.AppIniter for a provider app
-func ProviderAppIniter() (ibctesting.TestingApp, map[string]json.RawMessage) {
-	encoding := cosmoscmd.MakeEncodingConfig(appProvider.ModuleBasics)
-	testApp := appProvider.New(log.NewNopLogger(), tmdb.NewMemDB(), nil, true, map[int64]bool{},
-		simapp.DefaultNodeHome, 5, encoding, simapp.EmptyAppOptions{}).(ibctesting.TestingApp)
-	return testApp, appProvider.NewDefaultGenesisState(encoding.Marshaler)
 }

--- a/tests/e2e/interchain_security_test.go
+++ b/tests/e2e/interchain_security_test.go
@@ -3,12 +3,11 @@ package e2e_test
 import (
 	"testing"
 
-	appConsumer "github.com/cosmos/interchain-security/app/consumer"
-	//appConsumerDemocracy "github.com/cosmos/interchain-security/app/consumer-democracy"
+	appConsumer "github.com/NicholasDotSol/duality/app"
 	appProvider "github.com/cosmos/interchain-security/app/provider"
 	"github.com/cosmos/interchain-security/tests/e2e"
 
-	//icstestingutils "github.com/cosmos/interchain-security/testutil/ibc_testing"
+	icsappiniters "github.com/cosmos/interchain-security/testutil/ibc_testing"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -24,7 +23,7 @@ func TestCCVTestSuite(t *testing.T) {
 	// Pass in concrete app types that implement the interfaces defined in /testutil/e2e/interfaces.go
 	ccvSuite := e2e.NewCCVTestSuite[*appProvider.App, *appConsumer.App](
 		// Pass in ibctesting.AppIniters for provider and consumer.
-		ProviderAppIniter, ConsumerAppIniter, []string{})
+		icsappiniters.ProviderAppIniter, DualityAppIniter, []string{})
 
 	// Run tests
 	suite.Run(t, ccvSuite)

--- a/tests/e2e/interchain_security_test.go
+++ b/tests/e2e/interchain_security_test.go
@@ -3,8 +3,8 @@ package e2e_test
 import (
 	"testing"
 
-	appConsumer "github.com/NicholasDotSol/duality/app"
-	appProvider "github.com/cosmos/interchain-security/app/provider"
+	appduality "github.com/NicholasDotSol/duality/app"
+	appprovider "github.com/cosmos/interchain-security/app/provider"
 	"github.com/cosmos/interchain-security/tests/e2e"
 
 	icsappiniters "github.com/cosmos/interchain-security/testutil/ibc_testing"
@@ -21,7 +21,7 @@ import (
 func TestCCVTestSuite(t *testing.T) {
 
 	// Pass in concrete app types that implement the interfaces defined in /testutil/e2e/interfaces.go
-	ccvSuite := e2e.NewCCVTestSuite[*appProvider.App, *appConsumer.App](
+	ccvSuite := e2e.NewCCVTestSuite[*appprovider.App, *appduality.App](
 		// Pass in ibctesting.AppIniters for provider and consumer.
 		icsappiniters.ProviderAppIniter, DualityAppIniter, []string{})
 


### PR DESCRIPTION
Problem was caused by passing in a type parameter that was different from the app type your appIniter returns (the duality app.go). See the ICS example [here](https://github.com/cosmos/interchain-security/blob/main/tests/e2e/instance_test.go#L24)