### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,101 @@
+#!/usr/bin/make -f
+
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+COMMIT := $(shell git log -1 --format='%H')
+
+# don't override user values
+ifeq (,$(VERSION))
+  VERSION := $(shell git describe --exact-match 2>/dev/null)
+  # if VERSION is empty, then populate it with branch's name and raw commit hash
+  ifeq (,$(VERSION))
+    VERSION := $(BRANCH)-$(COMMIT)
+  endif
+endif
+
+LEDGER_ENABLED ?= true
+DOCKER := $(shell which docker)
+TM_VERSION := $(shell go list -m github.com/tendermint/tendermint | sed 's:.* ::') # grab everything after the space in "github.com/tendermint/tendermint v0.34.7"
+BUILDDIR ?= $(CURDIR)/bin
+CHAIN_NAME = duality
+DAEMON_NAME = dualityd
+
+export GO111MODULE = on
+
+all: install
+
+###############################################################################
+# Build / Install
+###############################################################################
+
+# process build tags
+
+build_tags = netgo
+ifeq ($(LEDGER_ENABLED),true)
+  ifeq ($(OS),Windows_NT)
+    GCCEXE = $(shell where gcc.exe 2> NUL)
+    ifeq ($(GCCEXE),)
+      $(error gcc.exe not installed for ledger support, please install or set LEDGER_ENABLED=false)
+    else
+      build_tags += ledger
+    endif
+  else
+    UNAME_S = $(shell uname -s)
+    ifeq ($(UNAME_S),OpenBSD)
+      $(warning OpenBSD detected, disabling ledger support (https://github.com/cosmos/cosmos-sdk/issues/1988))
+    else
+      GCC = $(shell command -v gcc 2> /dev/null)
+      ifeq ($(GCC),)
+        $(error gcc not installed for ledger support, please install or set LEDGER_ENABLED=false)
+      else
+        build_tags += ledger
+      endif
+    endif
+  endif
+endif
+
+build_tags += $(BUILD_TAGS)
+build_tags := $(strip $(build_tags))
+
+whitespace :=
+whitespace += $(whitespace)
+comma := ,
+build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
+
+# process linker flags
+
+ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=$(CHAIN_NAME) \
+		  -X github.com/cosmos/cosmos-sdk/version.AppName=$(DAEMON_NAME) \
+		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
+		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
+		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)" \
+			-X github.com/tendermint/tendermint/version.TMCoreSemVer=$(TM_VERSION)
+
+ldflags += $(LDFLAGS)
+ldflags := $(strip $(ldflags))
+
+BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
+
+BUILD_TARGETS := build install
+
+build: BUILD_ARGS=-o $(BUILDDIR)/
+
+$(BUILD_TARGETS): go.sum
+	go $@ -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./...
+
+$(BUILDDIR)/:
+	mkdir -p $(BUILDDIR)/
+
+clean:
+	rm -rf $(BUILDDIR)/
+
+###############################################################################
+# Tests / CI
+###############################################################################
+
+test:
+	@go test -mod=readonly -race ./...
+
+ibctest:
+	cd ibctest && go test -race -v -run .
+
+.PHONY: test ibctest install build clean


### PR DESCRIPTION
I put together a Makefile with some basic commands. This is helpful as a developer so you don't have to manually run Go commands for everything and also streamlines the build process. The goal is to utilize this Makefile in `heighliner` so that we can build Docker images for Duality that can be fetched with a tag inside of the `ibctest` test cases.

https://github.com/orgs/strangelove-ventures/packages?repo_name=heighliner

`install` will compile the binary which will then be located in whatever directory `GOBIN` references
`build` will compile the binary into a subdirectory in the root named `bin`
`clean` will delete the `bin` directory
`test` will run all Go tests with the race detector enabled
`ibctest` will be utilized in a future PR to execute the integration/e2e tests that utilize `ibctest`