### PR TITLE
negative support and CLI examples

### DIFF
--- a/x/dex/client/cli/query_fee_tier.go
+++ b/x/dex/client/cli/query_fee_tier.go
@@ -45,9 +45,10 @@ func CmdListFeeTier() *cobra.Command {
 
 func CmdShowFeeTier() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show-fee-list [id]",
-		Short: "shows a FeeTier",
-		Args:  cobra.ExactArgs(1),
+		Use:     "show-fee-list [id]",
+		Short:   "shows a FeeTier",
+		Example: "show-fee-list 1",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 

--- a/x/dex/client/cli/query_filled_limit_order_tranche.go
+++ b/x/dex/client/cli/query_filled_limit_order_tranche.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -45,9 +46,10 @@ func CmdListFilledLimitOrderTranche() *cobra.Command {
 
 func CmdShowFilledLimitOrderTranche() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show-filled-limit-order-tranche [pair-id] [token-in] [tick-index] [tranche-index]",
-		Short: "shows a FilledLimitOrderTranche",
-		Args:  cobra.ExactArgs(4),
+		Use:     "show-filled-limit-order-tranche [pair-id] [token-in] [tick-index] [tranche-index]",
+		Short:   "shows a FilledLimitOrderTranche",
+		Example: "show-filled limit-order-tranche tokenA<>tokenB tokenA [10] 0",
+		Args:    cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 
@@ -55,6 +57,11 @@ func CmdShowFilledLimitOrderTranche() *cobra.Command {
 
 			argPairId := args[0]
 			argTokenIn := args[1]
+
+			if strings.HasPrefix(args[2], "[") && strings.HasSuffix(args[2], "]") {
+				args[2] = strings.TrimPrefix(args[2], "[")
+				args[2] = strings.TrimSuffix(args[2], "]")
+			}
 			argTickIndex, err := cast.ToInt64E(args[2])
 			if err != nil {
 				return err

--- a/x/dex/client/cli/query_get_user_positions.go
+++ b/x/dex/client/cli/query_get_user_positions.go
@@ -13,9 +13,10 @@ var _ = strconv.Itoa(0)
 
 func CmdShowUserPositions() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show-user-positions [address]",
-		Short: "shows a users current positions",
-		Args:  cobra.ExactArgs(1),
+		Use:     "show-user-positions [address]",
+		Short:   "shows a users current positions",
+		Example: "show-user-positions alice",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			reqAddress := args[0]
 

--- a/x/dex/client/cli/query_limit_order_tranche.go
+++ b/x/dex/client/cli/query_limit_order_tranche.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -12,9 +13,10 @@ import (
 
 func CmdListLimitOrderTranche() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list-limit-order-tranche [pair-id] [token-in]",
-		Short: "list all LimitOrderTranches",
-		Args:  cobra.ExactArgs(2),
+		Use:     "list-limit-order-tranche [pair-id] [token-in]",
+		Short:   "list all LimitOrderTranches",
+		Example: "list-limit-order-tranche tokenA<>tokenB tokenA",
+		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 
@@ -51,15 +53,20 @@ func CmdListLimitOrderTranche() *cobra.Command {
 
 func CmdShowLimitOrderTranche() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show-limit-order-tranche [pair-id] [tick-index] [token-in] [tranche-index]",
-		Short: "shows a LimitOrderTranche",
-		Args:  cobra.ExactArgs(4),
+		Use:     "show-limit-order-tranche [pair-id] [tick-index] [token-in] [tranche-index]",
+		Short:   "shows a LimitOrderTranche",
+		Example: "show-limit-order-tranche tokenA<>tokenB [5] tokenA 0",
+		Args:    cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 
 			queryClient := types.NewQueryClient(clientCtx)
 
 			argPairId := args[0]
+			if strings.HasPrefix(args[1], "[") && strings.HasSuffix(args[1], "]") {
+				args[1] = strings.TrimPrefix(args[1], "[")
+				args[1] = strings.TrimSuffix(args[1], "]")
+			}
 			argTickIndex := args[1]
 			argTokenIn := args[2]
 			argTrancheIndex := args[3]

--- a/x/dex/client/cli/query_limit_order_tranche_user.go
+++ b/x/dex/client/cli/query_limit_order_tranche_user.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -45,9 +46,10 @@ func CmdListLimitOrderTrancheUser() *cobra.Command {
 
 func CmdShowLimitOrderTrancheUser() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show-limit-order-pool-user-share-map [pairId] [tickIndex] [tokenIn] [trancheIndex] [address]",
-		Short: "shows a LimitOrderTrancheUser",
-		Args:  cobra.ExactArgs(5),
+		Use:     "show-limit-order-pool-user-share-map [pairId] [tickIndex] [tokenIn] [trancheIndex] [address]",
+		Short:   "shows a LimitOrderTrancheUser",
+		Example: "show-limit-order-pool-user-share-map tokenA<>tokenB [-5] tokenA 0 alice",
+		Args:    cobra.ExactArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 
@@ -56,6 +58,10 @@ func CmdShowLimitOrderTrancheUser() *cobra.Command {
 			argPairId := args[0]
 			argTickIndex := args[1]
 			argTokenIn := args[2]
+			if strings.HasPrefix(args[1], "[") && strings.HasSuffix(args[1], "]") {
+				args[1] = strings.TrimPrefix(args[1], "[")
+				args[1] = strings.TrimSuffix(args[1], "]")
+			}
 			argTrancheIndex := args[3]
 			argAddress := args[4]
 

--- a/x/dex/client/cli/query_pool_reserves.go
+++ b/x/dex/client/cli/query_pool_reserves.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -12,9 +13,10 @@ import (
 
 func CmdListPoolReserves() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list-pool-reserves [pair-id] [token-in]",
-		Short: "Query AllPoolReserves",
-		Args:  cobra.ExactArgs(2),
+		Use:     "list-pool-reserves [pair-id] [token-in]",
+		Short:   "Query AllPoolReserves",
+		Example: "list-pool-reserves tokenA<>tokenB tokenA",
+		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			reqPairId := args[0]
 			reqTokenIn := args[1]
@@ -54,15 +56,20 @@ func CmdListPoolReserves() *cobra.Command {
 
 func CmdShowPoolReserves() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show-pool-reserves [pair-id] [tick-index] [token-in] [fee]",
-		Short: "shows a PoolReserves",
-		Args:  cobra.ExactArgs(4),
+		Use:     "show-pool-reserves [pair-id] [tick-index] [token-in] [fee]",
+		Short:   "shows a PoolReserves",
+		Example: "show-pool-reserves tokenA<>tokenB [-5] tokenA 1",
+		Args:    cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 
 			queryClient := types.NewQueryClient(clientCtx)
 
 			argPairId := args[0]
+			if strings.HasPrefix(args[1], "[") && strings.HasSuffix(args[1], "]") {
+				args[1] = strings.TrimPrefix(args[1], "[")
+				args[1] = strings.TrimSuffix(args[1], "]")
+			}
 			argTickIndex := args[1]
 			argTokenIn := args[2]
 			argFee := args[3]

--- a/x/dex/client/cli/query_tick_liquidity.go
+++ b/x/dex/client/cli/query_tick_liquidity.go
@@ -11,9 +11,10 @@ import (
 
 func CmdListTickLiquidity() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list-tick-liquidity [pair-id] [token-in]",
-		Short: "list all tickLiquidity",
-		Args:  cobra.ExactArgs(2),
+		Use:     "list-tick-liquidity [pair-id] [token-in]",
+		Short:   "list all tickLiquidity",
+		Example: "list-tick-liquidity tokenA<>tokenB tokenA",
+		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 

--- a/x/dex/client/cli/query_tokens.go
+++ b/x/dex/client/cli/query_tokens.go
@@ -45,9 +45,10 @@ func CmdListTokens() *cobra.Command {
 
 func CmdShowTokens() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show-tokens [id]",
-		Short: "shows a Tokens",
-		Args:  cobra.ExactArgs(1),
+		Use:     "show-tokens [id]",
+		Short:   "shows a Tokens",
+		Example: "show-tokens 1",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 

--- a/x/dex/client/cli/query_user_deposits.go
+++ b/x/dex/client/cli/query_user_deposits.go
@@ -9,9 +9,10 @@ import (
 
 func CmdListUserDeposits() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list-user-deposits [address]",
-		Short: "list all users deposits",
-		Args:  cobra.ExactArgs(1),
+		Use:     "list-user-deposits [address]",
+		Short:   "list all users deposits",
+		Example: "list-user-deposits alice",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			reqAddress := args[0]
 

--- a/x/dex/client/cli/query_user_limit_orders.go
+++ b/x/dex/client/cli/query_user_limit_orders.go
@@ -9,9 +9,10 @@ import (
 
 func CmdListUserLimitOrders() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list-user-limit-orders [address]",
-		Short: "list all users limit orders",
-		Args:  cobra.ExactArgs(1),
+		Use:     "list-user-limit-orders [address]",
+		Short:   "list all users limit orders",
+		Example: "list-user-limit-orders alice",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			reqAddress := args[0]
 

--- a/x/dex/client/cli/testsuite/tx_test.go
+++ b/x/dex/client/cli/testsuite/tx_test.go
@@ -60,12 +60,12 @@ func (s *TxTestSuite) SetupSuite() {
 
 	val := s.network.Validators[0]
 	clientCtx := val.ClientCtx
-	args := append([]string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "10", "0", "1", "false"}, commonFlags...)
+	args := append([]string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "10", "[0]", "1", "false"}, commonFlags...)
 	cmd := dexClient.CmdDeposit()
 	_, err = cli.ExecTestCLICmd(clientCtx, cmd, args)
 	require.NoError(s.T(), err)
 
-	args = append([]string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "20", "TokenB", "10"}, commonFlags...)
+	args = append([]string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "[20]", "TokenB", "10"}, commonFlags...)
 	cmd = dexClient.CmdPlaceLimitOrder()
 	_, err = cli.ExecTestCLICmd(clientCtx, cmd, args)
 	require.NoError(s.T(), err)
@@ -117,24 +117,24 @@ func (s *TxTestSuite) TestTxCmdDeposit() {
 	}{
 		{
 			name:      "missing arguments",
-			args:      []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "10", "0", "false"},
+			args:      []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "10", "[0]", "false"},
 			expErr:    true,
 			expErrMsg: "Error: accepts 8 arg(s), received 7",
 		},
 		{
 			name:      "too many arguments",
-			args:      []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "10", "0", "0", "false", s.addr1.String()},
+			args:      []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "10", "[0]", "0", "false", s.addr1.String()},
 			expErr:    true,
 			expErrMsg: "Error: accepts 8 arg(s), received 9",
 		},
 		{
 			name:     "valid",
-			args:     []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "10", "0", "0", "false"},
+			args:     []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "10", "[0]", "0", "false"},
 			errInRes: false,
 		},
 		{
 			name:     "valid: multiple case",
-			args:     []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "0,0", "10,10", "25,25", "1,1", "false,false"},
+			args:     []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "0,0", "10,10", "[25,25]", "1,1", "false,false"},
 			errInRes: false,
 		},
 	}
@@ -174,7 +174,7 @@ func (s *TxTestSuite) TestTx2CmdWithdraw() {
 	}
 
 	//Deposit Funds
-	args := append([]string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "10", "0", "0", "false"}, commonFlags...)
+	args := append([]string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "10", "[0]", "0", "false"}, commonFlags...)
 	cmd := dexClient.CmdDeposit()
 	_, err := cli.ExecTestCLICmd(clientCtx, cmd, args)
 	require.NoError(s.T(), err)
@@ -189,24 +189,24 @@ func (s *TxTestSuite) TestTx2CmdWithdraw() {
 		{
 			// "withdrawl [receiver] [token-a] [token-b] [list of shares-to-remove] [list of tick-index] [list of fee indexes] ",
 			name:      "missing arguments",
-			args:      []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "0"},
+			args:      []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "[10]", "0"},
 			expErr:    true,
 			expErrMsg: "Error: accepts 6 arg(s), received 5",
 		},
 		{
 			name:      "too many arguments",
-			args:      []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "0", "1", s.addr1.String()},
+			args:      []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "[0]", "1", s.addr1.String()},
 			expErr:    true,
 			expErrMsg: "Error: accepts 6 arg(s), received 7",
 		},
 		{
 			name:     "valid",
-			args:     []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "0", "1"},
+			args:     []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "10", "[0]", "1"},
 			errInRes: false,
 		},
 		{
 			name:     "valid: multiple case",
-			args:     []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "2,2", "0,0", "0,1"},
+			args:     []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "2,2", "[0,0]", "0,1"},
 			errInRes: false,
 		},
 	}
@@ -316,19 +316,19 @@ func (s *TxTestSuite) TestTx4Cmd4laceLimitOrder() {
 		{
 			// "place-limit-order [receiver] [token-a] [token-b] [tick-index] [token-in] [amount-in]",,
 			name:      "missing arguments",
-			args:      []string{s.addr1.String(), "TokenA", "TokenB", "0", "TokenB"},
+			args:      []string{s.addr1.String(), "TokenA", "TokenB", "[0]", "TokenB"},
 			expErr:    true,
 			expErrMsg: "Error: accepts 6 arg(s), received 5",
 		},
 		{
 			name:      "too many arguments",
-			args:      []string{s.addr1.String(), "TokenA", "TokenB", "0", "TokenB", "10", "1"},
+			args:      []string{s.addr1.String(), "TokenA", "TokenB", "[0]", "TokenB", "10", "1"},
 			expErr:    true,
 			expErrMsg: "Error: accepts 6 arg(s), received 7",
 		},
 		{
 			name:     "valid",
-			args:     []string{s.addr1.String(), "TokenA", "TokenB", "0", "TokenB", "10"},
+			args:     []string{s.addr1.String(), "TokenA", "TokenB", "[0]", "TokenB", "10"},
 			errInRes: false,
 		},
 	}
@@ -368,7 +368,7 @@ func (s *TxTestSuite) TestTx5CmdCancelLimitOrder() {
 	}
 
 	// Place Limit Order
-	args := append([]string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "0", "TokenB", "10"}, commonFlags...)
+	args := append([]string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "[0]", "TokenB", "10"}, commonFlags...)
 	cmd := dexClient.CmdPlaceLimitOrder()
 	_, err := cli.ExecTestCLICmd(clientCtx, cmd, args)
 	require.NoError(s.T(), err)
@@ -383,19 +383,19 @@ func (s *TxTestSuite) TestTx5CmdCancelLimitOrder() {
 		{
 			//  "cancel-limit-order [receiver] [token-a] [token-b] [tick-index] [key-token] [key]"
 			name:      "missing arguments",
-			args:      []string{s.addr1.String(), "TokenA", "TokenB", "0", "TokenB"},
+			args:      []string{s.addr1.String(), "TokenA", "TokenB", "[0]", "TokenB"},
 			expErr:    true,
 			expErrMsg: "Error: accepts 6 arg(s), received 5",
 		},
 		{
 			name:      "too many arguments",
-			args:      []string{s.addr1.String(), "TokenA", "TokenB", "0", "TokenB", "0", "1"},
+			args:      []string{s.addr1.String(), "TokenA", "TokenB", "[0]", "TokenB", "0", "1"},
 			expErr:    true,
 			expErrMsg: "Error: accepts 6 arg(s), received 7",
 		},
 		{
 			name:     "valid",
-			args:     []string{s.addr1.String(), "TokenA", "TokenB", "0", "TokenB", "0"},
+			args:     []string{s.addr1.String(), "TokenA", "TokenB", "[0]", "TokenB", "0"},
 			errInRes: false,
 		},
 	}
@@ -436,7 +436,7 @@ func (s *TxTestSuite) TestTx6CmdWithdrawFilledLimitOrder() {
 	}
 
 	// Place Limit Order
-	args := append([]string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "0", "TokenB", "10"}, commonFlags...)
+	args := append([]string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "[0]", "TokenB", "10"}, commonFlags...)
 	cmd := dexClient.CmdPlaceLimitOrder()
 	_, err := cli.ExecTestCLICmd(clientCtx, cmd, args)
 	require.NoError(s.T(), err)
@@ -456,19 +456,19 @@ func (s *TxTestSuite) TestTx6CmdWithdrawFilledLimitOrder() {
 		{
 			//  "withdraw-filled-limit-order [receiver] [token-a] [token-b] [tick-index] [key-token] [key]"
 			name:      "missing arguments",
-			args:      []string{s.addr1.String(), "TokenA", "TokenB", "0", "TokenB"},
+			args:      []string{s.addr1.String(), "TokenA", "TokenB", "[0]", "TokenB"},
 			expErr:    true,
 			expErrMsg: "Error: accepts 6 arg(s), received 5",
 		},
 		{
 			name:      "too many arguments",
-			args:      []string{s.addr1.String(), "TokenA", "TokenB", "0", "TokenB", "0", "1"},
+			args:      []string{s.addr1.String(), "TokenA", "TokenB", "[0]", "TokenB", "0", "1"},
 			expErr:    true,
 			expErrMsg: "Error: accepts 6 arg(s), received 7",
 		},
 		{
 			name:     "valid",
-			args:     []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "0", "TokenB", "1"},
+			args:     []string{s.network.Validators[0].Address.String(), "TokenA", "TokenB", "[0]", "TokenB", "1"},
 			errInRes: false,
 		},
 	}

--- a/x/dex/client/cli/tx_cancel_limit_order.go
+++ b/x/dex/client/cli/tx_cancel_limit_order.go
@@ -15,16 +15,21 @@ var _ = strconv.Itoa(0)
 
 func CmdCancelLimitOrder() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "cancel-limit-order [receiver] [token-a] [token-b] [tick-index] [key-token] [key]",
-		Short: "Broadcast message CancelLimitOrder",
-		Args:  cobra.ExactArgs(6),
+		Use:     "cancel-limit-order [receiver] [token-a] [token-b] [tick-index] [key-token] [key]",
+		Short:   "Broadcast message CancelLimitOrder",
+		Example: "cancel-limit-order alice tokenA tokenB [-10] tokenA 0 --from alice",
+		Args:    cobra.ExactArgs(6),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argReceiver := args[0]
 			argTokenA := args[1]
 			argTokenB := args[2]
+
+			if strings.HasPrefix(args[3], "[") && strings.HasSuffix(args[3], "]") {
+				args[3] = strings.TrimPrefix(args[3], "[")
+				args[3] = strings.TrimSuffix(args[3], "]")
+			}
 			argTickIndex := args[3]
 
-			argTickIndex = strings.Trim(argTickIndex, "\"")
 			argTickIndexInt, err := strconv.Atoi(argTickIndex)
 			if err != nil {
 				return err

--- a/x/dex/client/cli/tx_deposit.go
+++ b/x/dex/client/cli/tx_deposit.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"log"
 	"strconv"
 	"strings"
 
@@ -18,16 +19,27 @@ var _ = strconv.Itoa(0)
 func CmdDeposit() *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:   "deposit [receiver] [token-a] [token-b] [list of amount-0] [list of amount-1] [list of tick-index] [list of fee] [deposit option parameters]",
-		Short: "Broadcast message deposit",
-		Args:  cobra.ExactArgs(8),
+		Use:     "deposit [receiver] [token-a] [token-b] [list of amount-0] [list of amount-1] [list of tick-index] [list of fee] [deposit option parameters]",
+		Short:   "Broadcast message deposit",
+		Example: "deposit alice tokenA tokenB 100,50 [-10,5] 1,1 false,false --from alice",
+		Args:    cobra.ExactArgs(8),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argReceiver := args[0]
 			argTokenA := args[1]
 			argTokenB := args[2]
 			argAmountsA := strings.Split(args[3], ",")
 			argAmountsB := strings.Split(args[4], ",")
+
+			if args[5] == "-" {
+				log.Printf("\"this is a test\": %v\n", "this is a test")
+			}
+
+			if strings.HasPrefix(args[5], "[") && strings.HasSuffix(args[5], "]") {
+				args[5] = strings.TrimPrefix(args[5], "[")
+				args[5] = strings.TrimSuffix(args[5], "]")
+			}
 			argTicksIndexes := strings.Split(args[5], ",")
+
 			argFeesIndexes := strings.Split(args[6], ",")
 			argDepositOptions := strings.Split(args[7], ",")
 
@@ -56,8 +68,7 @@ func CmdDeposit() *cobra.Command {
 			}
 
 			for _, s := range argTicksIndexes {
-				str := strings.Trim(s, "\"")
-				TickIndexInt, err := strconv.Atoi(str)
+				TickIndexInt, err := strconv.Atoi(s)
 				if err != nil {
 					return err
 				}

--- a/x/dex/client/cli/tx_place_limit_order.go
+++ b/x/dex/client/cli/tx_place_limit_order.go
@@ -17,16 +17,19 @@ var _ = strconv.Itoa(0)
 
 func CmdPlaceLimitOrder() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "place-limit-order [receiver] [token-a] [token-b] [tick-index] [token-in] [amount-in]",
-		Short: "Broadcast message PlaceLimitOrder",
-		Args:  cobra.ExactArgs(6),
+		Use:     "place-limit-order [receiver] [token-a] [token-b] [tick-index] [token-in] [amount-in]",
+		Short:   "Broadcast message PlaceLimitOrder",
+		Example: "place-limit-order alice tokenA tokenB [-10] tokenA 50 --from alice",
+		Args:    cobra.ExactArgs(6),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argReceiver := args[0]
 			argTokenA := args[1]
 			argTokenB := args[2]
+			if strings.HasPrefix(args[3], "[") && strings.HasSuffix(args[3], "]") {
+				args[3] = strings.TrimPrefix(args[3], "[")
+				args[3] = strings.TrimSuffix(args[3], "]")
+			}
 			argTickIndex := args[3]
-
-			argTickIndex = strings.Trim(argTickIndex, "\"")
 			argTickIndexInt, err := strconv.Atoi(argTickIndex)
 			if err != nil {
 				return err

--- a/x/dex/client/cli/tx_swap.go
+++ b/x/dex/client/cli/tx_swap.go
@@ -16,9 +16,10 @@ var _ = strconv.Itoa(0)
 
 func CmdSwap() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "swap [receiver] [amount-in] [tokenA] [tokenB] [token-in] [minOut] [priceLimit]",
-		Short: "Broadcast message swap",
-		Args:  cobra.ExactArgs(7),
+		Use:     "swap [receiver] [amount-in] [tokenA] [tokenB] [token-in] [minOut] [priceLimit]",
+		Short:   "Broadcast message swap",
+		Example: "swap alice 50 tokenA tokenB tokenA 25  --from alice",
+		Args:    cobra.ExactArgs(7),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argReceiver := args[0]
 			argAmountIn := args[1]

--- a/x/dex/client/cli/tx_withdrawl.go
+++ b/x/dex/client/cli/tx_withdrawl.go
@@ -18,15 +18,20 @@ var _ = strconv.Itoa(0)
 func CmdWithdrawl() *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:   "withdrawl [receiver] [token-a] [token-b] [list of shares-to-remove] [list of tick-index] [list of fee indexes] ",
-		Short: "Broadcast message withdrawl",
-		Args:  cobra.ExactArgs(6),
+		Use:     "withdrawl [receiver] [token-a] [token-b] [list of shares-to-remove] [list of tick-index] [list of fee indexes] ",
+		Short:   "Broadcast message withdrawl",
+		Example: "withdrawl alice tokenA tokenB 100,50 [-10,5] 1,1 --from alice",
+		Args:    cobra.ExactArgs(6),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argReceiver := args[0]
 			argTokenA := args[1]
 			argTokenB := args[2]
-
 			argSharesToRemove := strings.Split(args[3], ",")
+
+			if strings.HasPrefix(args[4], "[") && strings.HasSuffix(args[4], "]") {
+				args[4] = strings.TrimPrefix(args[4], "[")
+				args[4] = strings.TrimSuffix(args[4], "]")
+			}
 			argTickIndexes := strings.Split(args[4], ",")
 			argFeeIndexes := strings.Split(args[5], ",")
 
@@ -44,8 +49,7 @@ func CmdWithdrawl() *cobra.Command {
 			}
 
 			for _, s := range argTickIndexes {
-				str := strings.Trim(s, "\"")
-				TickIndexInt, err := strconv.Atoi(str)
+				TickIndexInt, err := strconv.Atoi(s)
 				if err != nil {
 					return err
 				}

--- a/x/dex/client/cli/tx_withdrawl_filled_limit_order.go
+++ b/x/dex/client/cli/tx_withdrawl_filled_limit_order.go
@@ -15,16 +15,20 @@ var _ = strconv.Itoa(0)
 
 func CmdWithdrawFilledLimitOrder() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "withdraw-filled-limit-order [receiver] [token-a] [token-b] [tick-index] [key-token] [key]",
-		Short: "Broadcast message WithdrawFilledLimitOrder",
-		Args:  cobra.ExactArgs(6),
+		Use:     "withdraw-filled-limit-order [receiver] [token-a] [token-b] [tick-index] [key-token] [key]",
+		Short:   "Broadcast message WithdrawFilledLimitOrder",
+		Example: "withdraw-filled-limit-order alice tokenA tokenB [-10] tokenA 0 --from alice",
+		Args:    cobra.ExactArgs(6),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argReceiver := args[0]
 			argTokenA := args[1]
 			argTokenB := args[2]
+			if strings.HasPrefix(args[3], "[") && strings.HasSuffix(args[3], "]") {
+				args[3] = strings.TrimPrefix(args[3], "[")
+				args[3] = strings.TrimSuffix(args[3], "]")
+			}
 			argTickIndex := args[3]
 
-			argTickIndex = strings.Trim(argTickIndex, "\"")
 			argTickIndexInt, err := strconv.Atoi(argTickIndex)
 			if err != nil {
 				return err


### PR DESCRIPTION
Fix negative integer support with CLI (Issue #319 )

- Change CLI to support negative values for tickIndices
- Add CLI examples to all tx and query commands
