### PR TITLE
Validate create gauge message fields

### DIFF
--- a/x/incentives/keeper/distribute.go
+++ b/x/incentives/keeper/distribute.go
@@ -29,7 +29,10 @@ func (k Keeper) ValueForShares(ctx sdk.Context, coin sdk.Coin, tick int64) (sdk.
 		return sdk.ZeroInt(), err
 	}
 	amount0, amount1 := pool.RedeemValue(coin.Amount, totalShares)
-	price1To0Center := dextypes.MustNewPrice(-1 * tick)
+	price1To0Center, err := dextypes.NewPrice(-1 * tick)
+	if err != nil {
+		return sdk.ZeroInt(), err
+	}
 	return amount0.ToDec().Add(price1To0Center.MulInt(amount1)).TruncateInt(), nil
 }
 

--- a/x/incentives/types/errors.go
+++ b/x/incentives/types/errors.go
@@ -8,9 +8,11 @@ import (
 
 // x/incentives module sentinel errors.
 var (
-	ErrNotStakeOwner      = sdkerrors.Register(ModuleName, 1, "msg sender is not the owner of specified stake")
-	ErrStakeupNotFound    = sdkerrors.Register(ModuleName, 2, "stakeup not found")
-	ErrGaugeNotActive     = sdkerrors.Register(ModuleName, 3, "cannot distribute from gauges when it is not active")
-	ErrInvalidGaugeStatus = sdkerrors.Register(ModuleName, 4, "Gauge status filter must be one of: ACTIVE_UPCOMING, ACTIVE, UPCOMING, FINISHED")
-	ErrMaxGaugesReached   = sdkerrors.Register(ModuleName, 5, "Gauge limit has been reached; additional gauges may be created once the gauge limit has been raised via governance proposal")
+	ErrNotStakeOwner              = sdkerrors.Register(ModuleName, 1, "msg sender is not the owner of specified stake")
+	ErrStakeupNotFound            = sdkerrors.Register(ModuleName, 2, "stakeup not found")
+	ErrGaugeNotActive             = sdkerrors.Register(ModuleName, 3, "cannot distribute from gauges when it is not active")
+	ErrInvalidGaugeStatus         = sdkerrors.Register(ModuleName, 4, "Gauge status filter must be one of: ACTIVE_UPCOMING, ACTIVE, UPCOMING, FINISHED")
+	ErrMaxGaugesReached           = sdkerrors.Register(ModuleName, 5, "Gauge limit has been reached; additional gauges may be created once the gauge limit has been raised via governance proposal")
+	ErrGaugePricingTickOutOfRange = sdkerrors.Register(ModuleName, 6, "cannot use an invalid price tick")
+	ErrGaugeDistrToTickOutOfRange = sdkerrors.Register(ModuleName, 7, "cannot use an distrTo tick")
 )


### PR DESCRIPTION
This fixes a bug that would prevent this distribution of rewards (not halt the chain as previously believed https://github.com/duality-labs/duality/blob/fix_gauge_tick_validation_bug/x/epochs/types/hooks.go#L39)